### PR TITLE
Fixed unexpected "function signature mismatch" error during executing method 'start authorization polling'

### DIFF
--- a/LICENSE.meta
+++ b/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 480a592e9f074dbdbf604a0b968cb4bf
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 50d4c27543b74f96a5f784510e7df4b5
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Modules/Authentication/AuthenticationModule.cs
+++ b/Runtime/Modules/Authentication/AuthenticationModule.cs
@@ -23,7 +23,7 @@ namespace PlayablesStudio.Plugins.YandexGamesSDK.Runtime.Modules.Authentication
         private static Action<bool, string> s_authCallback;
         private static Action<bool, UserProfile, string> s_profilePermissionCallback;
         private static Action s_pollingSuccessCallback;
-        private static Action s_pollingErrorCallback;
+        private static Action<string> s_pollingErrorCallback;
         private static AuthenticationModule s_instance;
 
         private static bool GetPlayerAccountIsAuthorized()
@@ -95,11 +95,11 @@ namespace PlayablesStudio.Plugins.YandexGamesSDK.Runtime.Modules.Authentication
             s_pollingSuccessCallback?.Invoke();
         }
 
-        [MonoPInvokeCallback(typeof(Action))]
-        private static void HandlePollingErrorCallback()
+        [MonoPInvokeCallback(typeof(Action<string>))]
+        private static void HandlePollingErrorCallback(string error)
         {
-            YGLogger.Error("Authorization polling failed");
-            s_pollingErrorCallback?.Invoke();
+            YGLogger.Error($"Authorization polling failed: {error}");
+            s_pollingErrorCallback?.Invoke(error);
         }
 
         [MonoPInvokeCallback(typeof(Action<string>))]
@@ -126,7 +126,7 @@ namespace PlayablesStudio.Plugins.YandexGamesSDK.Runtime.Modules.Authentication
 
         [DllImport("__Internal")]
         private static extern void AuthenticationApi_StartAuthorizationPolling(int repeatDelay,
-            Action successCallback, Action errorCallback);
+            Action successCallback, Action<string> errorCallback);
 
         [DllImport("__Internal")]
         private static extern void AuthenticationApi_RequestProfilePermission(
@@ -168,25 +168,25 @@ namespace PlayablesStudio.Plugins.YandexGamesSDK.Runtime.Modules.Authentication
             callback?.Invoke(false, "Authentication is only available in WebGL builds.");
 #endif
         }
-
-        public void StartAuthorizationPolling(int repeatDelay, Action successCallback = null,
-            Action errorCallback = null)
+        
+        public void StartAuthorizationPolling(TimeSpan repeatDelay, Action successCallback = null,
+            Action<string> errorCallback = null)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
             if (!YandexGamesSDK.IsInitialized)
             {
                 YGLogger.Error("SDK is not initialized. Call Initialize first.");
-                errorCallback?.Invoke();
+                errorCallback?.Invoke("sdk is not initialized");
                 return;
             }
 
             s_pollingSuccessCallback = successCallback;
             s_pollingErrorCallback = errorCallback;
-            AuthenticationApi_StartAuthorizationPolling(repeatDelay, HandlePollingSuccessCallback,
+            AuthenticationApi_StartAuthorizationPolling(repeatDelay.Milliseconds, HandlePollingSuccessCallback,
                 HandlePollingErrorCallback);
 #else
             YGLogger.Debug("Authorization polling is only available in WebGL builds.");
-            errorCallback?.Invoke();
+            errorCallback?.Invoke("only available in WebGL builds");
 #endif
         }
 

--- a/Runtime/Modules/Authentication/AuthenticationModule.cs
+++ b/Runtime/Modules/Authentication/AuthenticationModule.cs
@@ -87,8 +87,8 @@ namespace PlayablesStudio.Plugins.YandexGamesSDK.Runtime.Modules.Authentication
             }
         }
 
-        [MonoPInvokeCallback(typeof(Action))]
-        private static void HandlePollingSuccessCallback()
+        [MonoPInvokeCallback(typeof(Action<string>))]
+        private static void HandlePollingSuccessCallback(string jsonResponse)
         {
             YGLogger.Debug("Authorization polling succeeded");
             s_instance.AuthorizedInBackground?.Invoke();
@@ -96,10 +96,11 @@ namespace PlayablesStudio.Plugins.YandexGamesSDK.Runtime.Modules.Authentication
         }
 
         [MonoPInvokeCallback(typeof(Action<string>))]
-        private static void HandlePollingErrorCallback(string error)
+        private static void HandlePollingErrorCallback(string errorJson)
         {
-            YGLogger.Error($"Authorization polling failed: {error}");
-            s_pollingErrorCallback?.Invoke(error);
+            var response = JsonConvert.DeserializeObject<JSResponse<string>>(errorJson);
+            YGLogger.Error($"Authorization polling failed: {response.error}");
+            s_pollingErrorCallback?.Invoke(response.error);
         }
 
         [MonoPInvokeCallback(typeof(Action<string>))]
@@ -126,7 +127,7 @@ namespace PlayablesStudio.Plugins.YandexGamesSDK.Runtime.Modules.Authentication
 
         [DllImport("__Internal")]
         private static extern void AuthenticationApi_StartAuthorizationPolling(int repeatDelay,
-            Action successCallback, Action<string> errorCallback);
+            Action<string> successCallback, Action<string> errorCallback);
 
         [DllImport("__Internal")]
         private static extern void AuthenticationApi_RequestProfilePermission(

--- a/Runtime/Modules/Authentication/IAuthenticationModule.cs
+++ b/Runtime/Modules/Authentication/IAuthenticationModule.cs
@@ -35,10 +35,10 @@ namespace PlayablesStudio.Plugins.YandexGamesSDK.Runtime.Modules.Authentication
         /// <summary>
         /// Starts polling for authorization status in background
         /// </summary>
-        /// <param name="repeatDelay">Delay between polling attempts in milliseconds</param>
+        /// <param name="repeatDelay">Delay between polling attempts</param>
         /// <param name="successCallback">Called when authorization succeeds</param>
         /// <param name="errorCallback">Called if polling fails</param>
-        void StartAuthorizationPolling(int repeatDelay, Action successCallback = null, Action errorCallback = null);
+        void StartAuthorizationPolling(TimeSpan repeatDelay, Action successCallback = null, Action<string> errorCallback = null);
 
         /// <summary>
         /// Requests permission to access user's personal profile data

--- a/Runtime/Plugins/WebGL/YandexGamesPlugin.jslib
+++ b/Runtime/Plugins/WebGL/YandexGamesPlugin.jslib
@@ -40,6 +40,9 @@ const yandexGamesPluginLibrary = {
 
     initialize: function(successCallbackPtr, errorCallbackPtr) {
       if (yandexGamesPlugin.isInitializeCalled) {
+        yandexGamesPlugin.sendResponse(successCallbackPtr, errorCallbackPtr, null,
+            "Yandex Games SDK initialization is already called"
+        );
         return;
       }
       yandexGamesPlugin.isInitializeCalled = true;

--- a/Runtime/Plugins/WebGL/YandexGamesPlugin.jslib
+++ b/Runtime/Plugins/WebGL/YandexGamesPlugin.jslib
@@ -22,16 +22,20 @@ const yandexGamesPluginLibrary = {
       };
 
       const jsonPtr = yandexGamesPlugin.allocateUnmanagedString(JSON.stringify(response));
-      if (error) {
-        {{{ makeDynCall('vi', 'errorCallbackPtr') }}} (jsonPtr);
-        // see https://docs.unity3d.com/6000.0/Documentation/Manual/web-interacting-browser-deprecated.html#dyncall
-        // dynCall('vi', errorCallbackPtr, [jsonPtr]);
-      } else {
-        {{{ makeDynCall('vi', 'successCallbackPtr') }}} (jsonPtr);
-        // see https://docs.unity3d.com/6000.0/Documentation/Manual/web-interacting-browser-deprecated.html#dyncall
-        // dynCall('vi', successCallbackPtr, [jsonPtr]);
+      try {
+          if (error) {
+            {{{ makeDynCall('vi', 'errorCallbackPtr') }}} (jsonPtr);
+            // see https://docs.unity3d.com/6000.0/Documentation/Manual/web-interacting-browser-deprecated.html#dyncall
+            // dynCall('vi', errorCallbackPtr, [jsonPtr]);
+          } else {
+            {{{ makeDynCall('vi', 'successCallbackPtr') }}} (jsonPtr);
+            // see https://docs.unity3d.com/6000.0/Documentation/Manual/web-interacting-browser-deprecated.html#dyncall
+            // dynCall('vi', successCallbackPtr, [jsonPtr]);
+          }
       }
-      _free(jsonPtr);
+      finally {
+        _free(jsonPtr);
+      }
     },
 
     initialize: function(successCallbackPtr, errorCallbackPtr) {


### PR DESCRIPTION
```
Unhandled rejection: function signature mismatch Object
  | $An | @ | rough_riders.wasm.gz:0x7778f1
  | -- | -- | --
  | (anonymous) | @ | rough_riders.framework.js.gz:10
  | sendResponse | @ | rough_riders.framework.js.gz:10
  | (anonymous) | @ | rough_riders.framework.js.gz:10
```

The error is:
<img width="884" height="222" alt="image" src="https://github.com/user-attachments/assets/266e9c56-12ab-497d-93a3-a3b4816a59c4" />
The error source is:
<img width="840" height="484" alt="image" src="https://github.com/user-attachments/assets/71d955d5-b425-4c1d-a836-5a0c1f8e3fb4" />
